### PR TITLE
fix: stop drawing when pointer released outside canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,11 +135,16 @@
     canvas.addEventListener('mousemove', draw);
     canvas.addEventListener('mouseup', stopDrawing);
     canvas.addEventListener('mouseout', stopDrawing);
+    // Stop drawing if the mouse is released outside the canvas
+    window.addEventListener('mouseup', stopDrawing);
 
     // Event listeners for touch
     canvas.addEventListener('touchstart', e => { e.preventDefault(); startDrawing(e); });
     canvas.addEventListener('touchmove', e => { e.preventDefault(); draw(e); });
     canvas.addEventListener('touchend', e => { e.preventDefault(); stopDrawing(e); });
+    // Handle touch ending or cancellation outside the canvas
+    window.addEventListener('touchend', stopDrawing);
+    window.addEventListener('touchcancel', stopDrawing);
 
     clearBtn.addEventListener('click', () => {
       ctx.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## Summary
- stop drawing if mouse button released outside the canvas
- handle touch end/cancel outside the canvas to avoid accidental lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d0601c34833392034c977ae2a763